### PR TITLE
adding scripts for benchmarking simulation time

### DIFF
--- a/benchmarking/generate_vds.py
+++ b/benchmarking/generate_vds.py
@@ -1,0 +1,156 @@
+import matplotlib
+matplotlib.use('Agg')
+import matplotlib.pyplot as plt
+import numpy as np
+import h5py, time, os
+import argparse, glob
+
+
+def parse_input():
+    """
+    Parse command line input.
+    """
+    parser = argparse.ArgumentParser(description="Generate a virtual dataset from constituent h5 files.")
+    parser.add_argument('-i', '--input_dir', help='Path to a collection of h5 files', required=True, type=str)
+    parser.add_argument('-o', '--out_file', help='Output name', required=False, type=str)
+
+    return vars(parser.parse_args())
+
+
+def assemble_image_stack_batch(image_stack, index_map):
+    """
+    Assemble the image stack to obtain a 2D pattern according to the index map.
+    Modified from skopi.
+    :param image_stack: [stack num, panel num, panel pixel num x, panel pixel num y]
+    :param index_map: [panel num, panel pixel num x, panel pixel num y]
+    :return: [stack num, 2d pattern x, 2d pattern y]
+    """
+    # get boundary
+    index_max_x = np.max(index_map[:, :, :, 0]) + 1
+    index_max_y = np.max(index_map[:, :, :, 1]) + 1
+    # get stack number and panel number
+    stack_num = image_stack.shape[0]
+    panel_num = image_stack.shape[1]
+
+    # set holder
+    image = np.zeros((stack_num, index_max_x, index_max_y))
+
+    # loop through the panels
+    for l in range(panel_num):
+        image[:, index_map[l, :, :, 0], index_map[l, :, :, 1]] = image_stack[:, l, :, :]
+
+    return image
+
+
+def display_selection(input_dir, out_file, fnames, data_shapes):
+    """
+    Display a few images from the virtual dataset and confirm that they match
+    their correpsonding images from the constituent files.
+
+    :param input_dir: path to constituent h5 files
+    :param out_file: virtual dataset file 
+    :param fnames: list of constituent file names
+    :param data_shapes: dictionary of constituent data keys and their shapes
+    """
+    # set up
+    key = 'intensities'
+    images_vds = np.zeros((3,) + data_shapes[key][1:])
+    images_ind = np.zeros((3,) + data_shapes[key][1:])
+    n_batch, n_total = data_shapes[key][0], data_shapes[key][0] * len(fnames)
+    rand_ind = np.random.randint(0, high=n_total, size=3)
+
+    # retrieve virtual dataset images
+    with h5py.File(out_file, "r") as f:
+        pixel_index_map = f['pixel_index_map'][:]
+        for num in range(3):
+            images_vds[num] = f['intensities'][rand_ind[num]]
+    
+    # retrieve constituent file images
+    for num in range(3):
+        quot, remainder = np.divmod(rand_ind[num], n_batch)
+        with h5py.File(fnames[quot], "r") as f:
+            images_ind[num] = f['intensities'][remainder]
+
+    # plot select images
+    f, ((ax1,ax2,ax3), (ax4,ax5,ax6)) = plt.subplots(2,3, figsize=(9,6))
+    
+    images_ind = assemble_image_stack_batch(images_ind, pixel_index_map)
+    images_vds = assemble_image_stack_batch(images_vds, pixel_index_map)
+
+    for num,ax in enumerate([ax1,ax2,ax3]):
+        ax.imshow(images_ind[num], vmax=3*images_ind[num].mean())
+    for num,ax in enumerate([ax4,ax5,ax6]):
+        ax.imshow(images_vds[num], vmax=3*images_ind[num].mean())
+    
+    for ax in [ax1,ax2,ax3,ax4,ax5,ax6]:
+        ax.set_xticks([])
+        ax.set_yticks([])
+    
+    ax1.set_ylabel("Constituent image", fontsize=12)
+    ax4.set_ylabel("Virtual dataset image", fontsize=12)
+
+    f.savefig(f"{input_dir}/check.png", dpi=300, bbox_inches='tight')
+
+    return
+
+
+def generate_vds(input_dir, out_file):
+    """
+    Generate a virtual dataset from all the .h5 files present in input_dir.
+
+    :param input_dir: directory containing input files
+    :param out_file: path to output virtual dataset file
+    """
+    # retrieve constituent file names and data shapes
+    fnames = glob.glob(f"{input_dir}/*.h5")
+    data_shapes = dict()
+    with h5py.File(fnames[0], "r") as f:
+        for key in f.keys():
+            data_shapes[key] = f[key].shape
+
+    # add orientations
+    key = 'orientations'
+    n_batch, n_total = data_shapes[key][0], data_shapes[key][0] * len(fnames)
+    layout = h5py.VirtualLayout(shape=(n_total,4), dtype=float)
+    for n in range(len(fnames)):
+        vsource = h5py.VirtualSource(fnames[n], key, shape=data_shapes[key])
+        layout[n_batch*n:n_batch*(n+1)] = vsource
+    with h5py.File(out_file, "w", libver="latest") as f:
+        f.create_virtual_dataset(key, layout, fillvalue=-1)
+        
+    # add images from constituent files
+    for key,dt in zip(['photons', 'intensities'], [int,float]):
+        n_batch, n_total = data_shapes[key][0], data_shapes[key][0] * len(fnames)
+        layout = h5py.VirtualLayout(shape=((n_total,)+data_shapes[key][1:]), dtype=dt)
+        for n in range(len(fnames)):
+            vsource = h5py.VirtualSource(fnames[n], key, shape=data_shapes[key])
+            layout[n_batch*n:n_batch*(n+1)] = vsource
+        with h5py.File(out_file, "a", libver="latest") as f:
+            f.create_virtual_dataset(key, layout, fillvalue=-1)
+
+    # add keys common to all files
+    for key,dt in zip(['pixel_index_map', 'pixel_position_reciprocal'], [int,float]):
+        layout = h5py.VirtualLayout(shape=data_shapes[key], dtype=dt)
+        for n in range(len(fnames)):
+            vsource = h5py.VirtualSource(fnames[n], key, shape=data_shapes[key])
+            layout[:] = vsource
+        with h5py.File(out_file, "a", libver="latest") as f:
+            f.create_virtual_dataset(key, layout, fillvalue=-1)
+
+    # check that vds generation worked
+    display_selection(input_dir, out_file, fnames, data_shapes)
+
+    return
+
+
+def main():
+
+    args = parse_input()
+    if args['out_file'] is None:
+        args['out_file'] = os.path.join(args['input_dir'], "simulated_vds.h5")
+
+    generate_vds(args['input_dir'], args['out_file'])
+
+
+if __name__ == '__main__':
+    main()

--- a/benchmarking/sim_mult_rank.py
+++ b/benchmarking/sim_mult_rank.py
@@ -1,0 +1,149 @@
+import matplotlib
+matplotlib.use('Agg')
+import matplotlib.pyplot as plt
+import numpy as np
+import skopi as sk
+import h5py, time, os
+import argparse
+from mpi4py import MPI
+
+
+def parse_input():
+    """
+    Parse command line input.
+    """
+    parser = argparse.ArgumentParser(description="SPI benchmarking for one rank.")
+    parser.add_argument('-b', '--beam_file', help='Beam file', required=True, type=str)
+    parser.add_argument('-p', '--pdb_file', help='Pdb file', required=True, type=str)
+    parser.add_argument('-d', '--det_info', help='Detector info. Either (n_pixels, length, distance) for SimpleSquare'+
+                        'or (det_type, geom_file, distance) for LCLSDetectors. det_type could be pnccd, for instance',
+                        required=True, nargs=3)
+    parser.add_argument('-e', '--experiment', help='SPI, SPI_agg, or FXS', required=True, type=str)
+    parser.add_argument('-n', '--n_images', help='Number of slices to compute', required=True, type=int)
+    parser.add_argument('-o', '--out_dir', help='Path to h5 output file', required=True, type=str)
+    parser.add_argument('-r', '--ref_xyz_file', help='xyz coordinates for holography reference', required=False, type=str)
+
+    return vars(parser.parse_args())
+
+
+def configure_detector(det_info):
+    """
+    Configure detector. 
+    
+    :param det_info: string of detector information, either
+        (n_pixels,length,distance) for SimpleSquare, or
+        (det_type, geom_file, distance) for LCLSDetectors.
+    :return det: detector object.
+    """
+    if det_info[0].isdigit():
+        n_pixels, det_size, det_dist = det_info
+        det = sk.SimpleSquareDetector(int(n_pixels), float(det_size), float(det_dist)) 
+    elif det_info[0] == 'pnccd':
+        det = sk.PnccdDetector(geom=det_info[1])
+        det.distance = float(det_info[2])
+    elif det_info[0] == 'cspad':
+        det = sk.CsPadDetector(geom=det_info[1])
+        det.distance = float(det_info[2])
+    elif det_info[0] == 'jungfrau':
+        det = sk.JungfrauDetector(geom=det_info[1], cameraConfig="fixedMedium")
+        det.distance = float(det_info[2])
+    elif args['det_info'][0] == 'epix10k':
+        det = sk.Epix10kDetector(geom=det_info[1], cameraConfig="fixedMedium")
+        det.distance = float(det_info[2])
+    else:
+        print("Detector type not recognized.")
+        return
+        
+    return det
+
+
+def setup_experiment(args, increase_factor=1e2):
+    """
+    Set up experiment class.
+    
+    :param args: dict containing beam, pdb, and detector info
+    :param increase_factor: factor by which to increase beam fluence
+    :return exp: SPIExperiment object
+    """
+    
+    beam = sk.Beam(args['beam_file'])
+    if increase_factor != 1:
+        beam.set_photons_per_pulse(increase_factor*beam.get_photons_per_pulse())
+    
+    particle = sk.Particle()
+    particle.read_pdb(args['pdb_file'], ff='WK')
+
+    det = configure_detector(args['det_info'])
+    jet_radius = 1e-6
+    
+    if args['experiment'] == 'SPI':
+        exp = sk.SPIExperiment(det, beam, particle)
+    elif args['experiment'] == 'SPI_agg':
+        exp = sk.SPIExperiment(det, beam, particle, n_part_per_shot=2)
+    elif args['experiment'] == 'FXS':
+        exp = sk.FXSExperiment(det, beam, jet_radius, [particle], n_part_per_shot=2)
+    elif args['experiment'] == 'holography':
+        xyz = np.loadtxt(args['ref_xyz_file'])
+        rparticle = sk.Particle()
+        rparticle.create_from_atoms([("AU", xyz[i]) for i in range(xyz.shape[0])])
+        exp = sk.HOLOExperiment(det, beam, [rparticle], [particle], jet_radius=jet_radius, ref_jet_radius=jet_radius)
+    else:        
+        print("Experiment type not recognized")
+        return
+
+    return exp
+
+
+def simulate(args):
+    """
+    Simulate diffraction images, dividing the computation between ranks, and assemble
+    the individual h5 files output by each rank into a single virtual dataset.
+    
+    :param args: dictionary of command line input
+    """
+    print("Simulating diffraction images")
+    
+    # set up MPI communicator
+    comm = MPI.COMM_WORLD
+    rank = comm.rank
+    size = comm.size
+    
+    # determining number of images per rank
+    n_batch, remainder = np.divmod(args['n_images'], size)
+    if remainder != 0:
+        print(f"Warning: number of requested images not divisible by number of ranks")
+        print(f"Reducing images per rank to {n_batch}")
+        args['n_images'] = size * n_batch
+    
+    # set up experiment 
+    exp = setup_experiment(args)
+    
+    # simulate images and save to h5 file
+    start_time = time.time()
+    f = h5py.File(os.path.join(args["out_dir"], f"simulated_{rank}.h5"), "w")
+    f.create_dataset("pixel_position_reciprocal", data=exp.det.pixel_position_reciprocal) # s-vectors in m-1 
+    f.create_dataset("pixel_index_map", data=exp.det.pixel_index_map) # indexing map for reassembly
+
+    photons = f.create_dataset("photons", shape=((n_batch,) + exp.det.shape))
+    intensities = f.create_dataset("intensities", shape=((n_batch,) + exp.det.shape))
+    orientations = f.create_dataset("orientations", shape=(n_batch, 4))
+    
+    for num in range(n_batch):
+        results = exp.generate_image_stack(return_intensities=True, return_photons=True, return_orientations=True)
+        photons[num,:,:], intensities[num,:,:], orientations[num] = results[0][0], results[0][1], results[1]
+    f.close()
+    
+    return
+
+
+def main():
+
+    args = parse_input()
+    if not os.path.isdir(args['out_dir']):
+        os.mkdir(args['out_dir'])
+
+    simulate(args)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Two scripts for generating large datasets:
- sim_mult_rank.py, which uses MPI parallelization to divide up the requested number of images across ranks. Each rank will write a batch of images to a separate h5 file. This script is fairly general in terms of its input, and can be used to run all skopi experiment and detector types. However, it hasn't been extended to include noise beyond quantization error.
- generate_vds.py, which stitches h5 files together into a single virtual dataset. Unfortunately I couldn't get this to work in the sim_mult_rank.py script: trying to do this on a single rank resulted in the virtual dataset containing the fill_value rather than the correct information. The same function works correctly when run from a non-MPI script. As shown below, this script also produces an image confirming that the virtual dataset correctly maps to images in the constituent h5 files as shown below.

![check](https://user-images.githubusercontent.com/6363287/115644841-19875c80-a2d4-11eb-9771-41ad2552ae2d.png)
